### PR TITLE
Update rustc-guide to rustc-dev-guide

### DIFF
--- a/minutes/2019-10-10.md
+++ b/minutes/2019-10-10.md
@@ -48,7 +48,7 @@
             - you could always invoke them directly
     [x] [Stabilize --extern flag without a path.](https://github.com/rust-lang/rust/pull/64882)
         * [ ] Some back & forth, lang is fine, t-compiler can do FCP…
-        * [ ] Also ehuss made a rustc-guide PR.
+        * [ ] Also ehuss made a rustc-dev-guide PR.
     * [ ] [Fully integrate derive helpers into name resolution](https://github.com/rust-lang/rust/pull/64694)
         * [ ] Felix is not here
     * [ ] [Stabilize nested self receivers](https://github.com/rust-lang/rust/pull/64325)

--- a/minutes/2020-01-09.md
+++ b/minutes/2020-01-09.md
@@ -143,7 +143,7 @@ None this week
     - Let’s have a design meeting.
 - [~~Tracking issue for RFC 2091: Implicit caller location #47809~~](https://github.com/rust-lang/rust/issues/47809)
     - nominated because anp has implemented this and would like to extend to trait items, which (contrary to what we previously thought when RFC was accepted) don’t seem to pose much difficulty
-    - niko requested a summary of impl strategy for rustc-guide plus reference where appropriate, but the belief is that this is generally straightforward
+    - niko requested a summary of impl strategy for rustc-dev-guide plus reference where appropriate, but the belief is that this is generally straightforward
         - I *believe* this works by a modification to the Rust ABI, and when we make a fn pointer we generate a small shim around it, so that as long as you do static dispatch, it works fine, and dynamic dispatch (either through `dyn` or `fn` type) will “cut the chain”, but I’ve not read all the PRs. —niko 
     - conclusion: let’s do it, even though we don’t have a lot of folks here
 - [~~floating point to integer casts can cause undefined behaviour #10184~~](https://github.com/rust-lang/rust/issues/10184)


### PR DESCRIPTION
The `rustc-guide` is being renamed to the `rustc-dev-guide`. The discussion is in rust-lang/rustc-guide#470.

This PR revises `rustc-guide` to `rustc-dev-guide` in the Markdown files

Transition tracker: rust-lang/rustc-guide#602