### PR TITLE
Mark mermaid.min.js as binary so it doesn't show up in grep

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Not useful to get grep results from
+mermaid.min.js binary


### PR DESCRIPTION
mermaid.min.js contains a giant blob of minified JavaScript. If a
`git grep` happens to match inside it, it'll display the entire file as
a result, disrupting the ability to grep for anything else. Use
`.gitattributes` to mark it as binary, so it just shows up as "Binary
file mermaid.min.js matches" instead.