### PR TITLE
We no longer record meetings by default.

### DIFF
--- a/src/calendar.md
+++ b/src/calendar.md
@@ -2,7 +2,7 @@
 
 We have a lang-team calendar that shows the time for our various meetings.
 Meetings are generally open to anyone who wants to listen in. We also try to
-post [minutes and recordings](./minutes.md) on a "best-effort" basis from our
+post [minutes](./minutes.md) (and recordings, if any) on a "best-effort" basis from our
 meetings.
 
 - [View calendar][caldav] -- use this to view the calendar online and add it to your Google Calendar

--- a/src/meetings.md
+++ b/src/meetings.md
@@ -2,10 +2,18 @@
 
 The lang team has several standing meetings. The current timing for these
 can be found on the [lang team calendar](./calendar.html). We
-generally record our public meetings and post the recordings in our
-[YouTube playlist] (along with automatically created subtitles). We
-also publish notes and minutes in written form in this github
+publish notes and minutes in written form in this github
 repository.
+
+Dy default, our triage and design meetings are not recorded, in order to
+encourage engagement from a broad audience. We may record certain design
+meetings, evaluated on a case-by-case basis, and only with the agreement of all
+participants. Any intention to record a design meeting will be established at
+that time that meeting is scheduled during the monthly planning meeting and
+included in the blog post announcing the upcoming meetings.
+
+Our [YouTube playlist] has recordings of some of our past meetings
+(along with automatically created subtitles).
 
 [youtube playlist]: https://www.youtube.com/playlist?list=PL85XCvVPmGQg-gYy7R6a_Y91oQLdsbSpa
 


### PR DESCRIPTION
We no longer record meetings by default.

Close #100.