### PR TITLE
Add missing CNAME file for GitHub pages

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,6 +7,7 @@ title = "The Rust Language Design Team"
 
 [output.html]
 additional-js =["mermaid.min.js", "mermaid-init.js"]
+cname = "lang-team.rust-lang.org"
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Also discussed here https://github.com/rust-lang/lang-team/issues/238,  the CNAME file was being [generated by the Travis CI](https://github.com/rust-lang/lang-team/commit/c23410f598cd1e01d232ad927673368565fcb0ae), but the CNAME creation command was not added when moving to GH actions.

mdBook supports an [option for creating a CNAME file](https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options), so I've added it there and tested locally that its created at the root of the output folder with `mdbook build`.

CNAME files are required to display custom domains on whichever branch that GitHub Pages uses.