### PR TITLE
Revert "Add missing CNAME file for GitHub pages"

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,6 @@ title = "The Rust Language Design Team"
 
 [output.html]
 additional-js =["mermaid.min.js", "mermaid-init.js"]
-cname = "lang-team.rust-lang.org"
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Reverts rust-lang/lang-team#239

See https://github.com/rust-lang/infra-team/issues/84#issuecomment-1830745515. We should re-land this once we are able to use the lang-team subdomain again.