### PR TITLE
Update hackmd link to a public link

### DIFF
--- a/src/meetings/backlog-bonanza.md
+++ b/src/meetings/backlog-bonanza.md
@@ -26,4 +26,4 @@ Here are the labels we apply during the process and their meaning:
 
 ## Where can I find the minutes?
 
-Currently the minutes are tracked in the issues themselves, but we also create hackmd documents in the [Rust lang team](https://hackmd.io/team/rust-lang-team?nav=overview).
+Currently the minutes are tracked in the issues themselves, but we also create hackmd documents in the [Rust lang team](https://hackmd.io/@rust-lang-team).


### PR DESCRIPTION
The link to hackmd is restricted to team members. There is a corresponding public link which I have inserted here. Unfortunately the view isn't the same. I could add both links if that would help, it depends on who the audience is here.
