### PR TITLE
Fix link to agenda template

### DIFF
--- a/src/meetings/design.md
+++ b/src/meetings/design.md
@@ -15,7 +15,7 @@ In that meeting, we choose what design meetings we will hold the rest of the mon
 
 To generate the agenda for the planning meeting, you can use the following link and then copy/paste the generated text into a fresh hackmd page:
 
-https://triage.rust-lang.org/agenda/lang/planning
+<https://triage.rust-lang.org/agenda/lang/planning>
 
 ## How do I propose a design meeting?
 


### PR DESCRIPTION
Not all markdown implementations automatically turn bare URLs into links. Surrounding it in `<>` will make it consistent.