### PR TITLE
Add the `Design meeting:` prefix in the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-proposal.md
+++ b/.github/ISSUE_TEMPLATE/meeting-proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Design meeting proposal
 about: Propose a topic for the design meeting.
-title: "(My meeting proposal)"
+title: "Design meeting: (My meeting proposal)"
 labels: meeting-proposal, T-lang
 assignees: ''
 


### PR DESCRIPTION
All the design meeting issues begin with the text `Design meeting:` in their title. Adding it into the template to fix a teeny tiny papercut.