### PR TITLE
nominate.md: update list of repositories

### DIFF
--- a/src/how_to/nominate.md
+++ b/src/how_to/nominate.md
@@ -35,6 +35,7 @@ Nomination is currently supported on the following repositories:
 - rust-lang/rust
 - rust-lang/reference
 - rust-lang/lang-team
+- rust-lang/compiler-team
 
 (This set is defined by the `nominated` list in the [triagebot source code](https://github.com/rust-lang/triagebot/blob/master/src/agenda.rs))
 


### PR DESCRIPTION
Since rust-lang/triagebot#1594 the `rust-lang/compiler-team` repo has been supported for inclusion in the lang team agenda, e.g. rust-lang/compiler-team#570 was included in the 2022-11-22 agenda.