### PR TITLE
Repoint default branch references

### DIFF
--- a/minutes/2019-03-14.md
+++ b/minutes/2019-03-14.md
@@ -64,7 +64,7 @@ These are the "minutes" from the meeting itself. You can view the
 
 # Unsafe code guidelines 
 
-[Link to the writeup](https://github.com/rust-lang/lang-team/blob/master/working-groups/unsafe-code-guidelines/notes/2019-03-14.md)
+[Link to the writeup](https://github.com/rust-lang/lang-team/blob/main/working-groups/unsafe-code-guidelines/notes/2019-03-14.md)
 
 
 ## RFCs and what form it should take

--- a/minutes/2020-01-02.md
+++ b/minutes/2020-01-02.md
@@ -128,7 +128,7 @@ None this week
 
 * [ ] [mem::zeroed/uninit: panic on types that do not permit zero-initialization #66059](https://github.com/rust-lang/rust/pull/66059)
 
-    * no updates since [last meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2019-12-19.md)
+    * no updates since [last meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2019-12-19.md)
     * TL;DR of what we said before
         * Centril thinks it would be good to have the full plan as "prose" and FCP that one so we don't have to re-FCP every step.
     * Update: [crater regressions categorized](https://github.com/rust-lang/rust/pull/66059#issuecomment-568445970)

--- a/minutes/2020-01-09.md
+++ b/minutes/2020-01-09.md
@@ -98,7 +98,7 @@ None this week
 - [~~permit negative impls for non-auto traits #68004~~](https://github.com/rust-lang/rust/pull/68004)
     - (see above)
 - [~~mem::zeroed/uninit: panic on types that do not permit zero-initialization~~](https://github.com/rust-lang/rust/pull/66059) ~~#66059~~
-    - no updates since [last meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2019-12-19.md)
+    - no updates since [last meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2019-12-19.md)
     - TL;DR of what we said before
         - Centril thinks it would be good to have the full plan as "prose" and FCP that one so we don't have to re-FCP every step.
     - Update: [crater regressions categorized](https://github.com/rust-lang/rust/pull/66059#issuecomment-568445970)

--- a/minutes/2020-02-06.md
+++ b/minutes/2020-02-06.md
@@ -10,7 +10,7 @@
 - Centril to create issue to remove existing lint against nested unsafe blocks, add a allow-by-default lint encouraging them
 - Niko to write comment on RFC#2585 summarizing conversation from meeting
 ## Upcoming design meetings
-- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-03-specialization-review.md)
+- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-03-specialization-review.md)
 - Feb 10 — Ralf + `UnsafeCell` bugs ([#55005](https://github.com/rust-lang/rust/issues/55005), [#68206](https://github.com/rust-lang/rust/issues/68206))
     - Ralf may have less time available
 - Feb 17 — (Niko is unavailable)

--- a/minutes/2020-02-27.md
+++ b/minutes/2020-02-27.md
@@ -12,9 +12,9 @@ Migrating back from [the hackmd](https://hackmd.io/XP0KTNosR52BVQ1nUyyITQ?edit)
     - https://github.com/rust-lang/rust/pull/69245
 - josh to post a comment on https://github.com/rust-lang/rust/issues/68905 saying “can’t we just stabilize these names”?
 ## Upcoming design meetings
-- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-03-specialization-review.md)
+- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-03-specialization-review.md)
 - ~~Feb 10 — Ralf +~~ `~~UnsafeCell~~` ~~bugs (~~[~~#55005~~](https://github.com/rust-lang/rust/issues/55005)~~,~~ [~~#68206~~](https://github.com/rust-lang/rust/issues/68206)~~)~~
-    - [Notes uploaded here (along with video)](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md)
+    - [Notes uploaded here (along with video)](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md)
     - **Question:** Would someone care to take a stab at “summarizing”? Maybe writing a comment on the MMIO in particular that summarized the impact there? — Niko will try
 - ~~Feb 17 — (Niko is unavailable)~~
 - March 9 —  mental health day, nothing scheduled
@@ -241,7 +241,7 @@ None this week
 [**Nominated issues**](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AI-nominated+label%3AT-lang+)
 
 - [~~Arc::drop has a (potentially) dangling shared ref #55005~~](https://github.com/rust-lang/rust/issues/55005)
-    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
     - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
 - [~~floating point to integer casts can cause undefined behaviour #10184~~](https://github.com/rust-lang/rust/issues/10184)
     - [last time we talked](https://github.com/rust-lang/rust/issues/10184#issuecomment-559538629), we concluded that it made sense to
@@ -268,7 +268,7 @@ None this week
 [**Nominated RFCs**](https://github.com/rust-lang/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3AI-nominated+label%3AT-lang)
 
 - RFC for unsafe blocks in unsafe fn [#2585](https://github.com/rust-lang/rfcs/pull/2585)
-    - still pending the actions we discussed on [2020-01-23](https://github.com/rust-lang/lang-team/blob/master/minutes/2020-01-23.md): 
+    - still pending the actions we discussed on [2020-01-23](https://github.com/rust-lang/lang-team/blob/main/minutes/2020-01-23.md): 
     - Resolved:
         - Remove the existing lint
         - Add a allow-by-default lint for unsafe code in an unsafe fn without an unsafe function

--- a/minutes/2020-03-05.md
+++ b/minutes/2020-03-05.md
@@ -13,9 +13,9 @@ Migrating back from [the hackmd](https://hackmd.io/XP0KTNosR52BVQ1nUyyITQ?edit)
 - simulacrum to post a comment on #67058 asking whether libs will stabilize them
 - scottmcm to post a comment on RFC 2585 with consensus below and/or talk to Ralf
 ## Upcoming design meetings
-- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-03-specialization-review.md)
+- [~~Feb 3 — Specialization infomercial (presented by Niko)~~](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-03-specialization-review.md)
 - ~~Feb 10 — Ralf +~~ `~~UnsafeCell~~` ~~bugs (~~[~~#55005~~](https://github.com/rust-lang/rust/issues/55005)~~,~~ [~~#68206~~](https://github.com/rust-lang/rust/issues/68206)~~)~~
-    - [Notes uploaded here (along with video)](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md)
+    - [Notes uploaded here (along with video)](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md)
     - **Question:** Would someone care to take a stab at “summarizing”? Maybe writing a comment on the MMIO in particular that summarized the impact there? — Niko will try
 - ~~Feb 17 — (Niko is unavailable)~~
 - March 9 —  (nothing)
@@ -168,7 +168,7 @@ None this week
 
 - [~~`is_x86_feature_detected!("avx512f")` fails to build on nightly~~](https://github.com/rust-lang/rust/issues/68905)
 - [Arc::drop has a (potentially) dangling shared ref #55005](https://github.com/rust-lang/rust/issues/55005)
-    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
     - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
     - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
         - would have to deal with conflicts of inherent methods

--- a/minutes/2020-03-12.md
+++ b/minutes/2020-03-12.md
@@ -203,7 +203,7 @@ None this week
 
 - [~~`is_x86_feature_detected!("avx512f")` fails to build on nightly~~](https://github.com/rust-lang/rust/issues/68905)
 - [Arc::drop has a (potentially) dangling shared ref #55005](https://github.com/rust-lang/rust/issues/55005)
-    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
     - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
     - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
         - would have to deal with conflicts of inherent methods

--- a/minutes/2020-03-19.md
+++ b/minutes/2020-03-19.md
@@ -215,7 +215,7 @@ None this week
 
 - [~~`is_x86_feature_detected!("avx512f")` fails to build on nightly~~](https://github.com/rust-lang/rust/issues/68905)
 - [Arc::drop has a (potentially) dangling shared ref #55005](https://github.com/rust-lang/rust/issues/55005)
-    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
     - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
     - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
         - would have to deal with conflicts of inherent methods

--- a/minutes/2020-03-26.md
+++ b/minutes/2020-03-26.md
@@ -283,7 +283,7 @@ None this week
 [**Nominated issues**](https://github.com/rust-lang/rust/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3AI-nominated+label%3AT-lang+)
 
 - [Arc::drop has a (potentially) dangling shared ref #55005](https://github.com/rust-lang/rust/issues/55005)
-    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+    - had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
     - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
     - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
         - would have to deal with conflicts of inherent methods

--- a/minutes/2020-04-02.md
+++ b/minutes/2020-04-02.md
@@ -394,7 +394,7 @@ Example:
  
 [**Arc::drop has a (potentially) dangling shared ref #55005**](https://github.com/rust-lang/rust/issues/55005)
 
-- had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+- had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
 - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
 - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
     - would have to deal with conflicts of inherent methods

--- a/minutes/2020-04-09.md
+++ b/minutes/2020-04-09.md
@@ -534,7 +534,7 @@ If we choose 2, this `enum` would compile (and `arbitrary_enum_discriminant` may
 
 [**Arc::drop has a (potentially) dangling shared ref #55005**](https://github.com/rust-lang/rust/issues/55005)
 
-- had a [design meeting](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
+- had a [design meeting](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-02-10-References-and-dereferenceable.md) but didn’t reach a firm conclusion
 - **next step:** somebody needs to write up the implications of that meeting for this issue in a clear way
 - a possible next step: adding support for `*const self` methods so that we can have a `fetch_sub` on `AtomicUsize` that takes `*const self`
     - would have to deal with conflicts of inherent methods

--- a/minutes/2021-03-02.md
+++ b/minutes/2021-03-02.md
@@ -161,7 +161,7 @@ pub struct AlignedTo<Aligner, T> {
 
 **Link:** https://github.com/rust-lang/rust/pull/80080
 
-* [Discussed last week in some depth](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-02-23.md#allow-qualified-paths-in-struct-construction-both-expressions-and-patterns-rust80080)
+* [Discussed last week in some depth](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-02-23.md#allow-qualified-paths-in-struct-construction-both-expressions-and-patterns-rust80080)
 * It seems like we didn't note down a clear resolution, but there were some notes about what expectations were
     * rylev: The action item was to try to get all uses of qualified path struct construction and pattern implemented. This is still WIP
 * Next steps?

--- a/minutes/2021-04-20.md
+++ b/minutes/2021-04-20.md
@@ -137,7 +137,7 @@ impl Foo for MyType {
 
 **Link:** https://github.com/rust-lang/rust/pull/81789
 
-- [Discussed on 2021-03-30](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-03-30.md#implement-new-lint-for-detecting-buggy-pointer-to-int-casts-rust81789) in depth
+- [Discussed on 2021-03-30](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-03-30.md#implement-new-lint-for-detecting-buggy-pointer-to-int-casts-rust81789) in depth
 - Our consensus seemed to be lost, but we didn't have much follow-up on the issue
 - [ ] [2021-03-30]: Taylor to write up a summary of the ptr cast discussion
 - Pending crater run as well, which may inform the discussion

--- a/minutes/2021-06-22.md
+++ b/minutes/2021-06-22.md
@@ -228,7 +228,7 @@ Already discussed
 **Link:** https://github.com/rust-lang/rust/pull/84364
 
 * Last time we discussed it, concerns were raised
-* [Summary from prior meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-05-11.md#add-expr202x-macro-pattern-rust84364)
+* [Summary from prior meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-05-11.md#add-expr202x-macro-pattern-rust84364)
 
 ### "Allow struct and enum to contain inner attrs" rust#84414
 

--- a/minutes/2021-06-29.md
+++ b/minutes/2021-06-29.md
@@ -120,7 +120,7 @@ tags: triage-meeting
 
 **Link:** https://github.com/rust-lang/rfcs/pull/2991
 
-[Conclusion from last meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-06-22.md#rfc-add-target-configuration-rfcs2991):
+[Conclusion from last meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-06-22.md#rfc-add-target-configuration-rfcs2991):
 
 * Niko to drop concern about matching the entire target string (done)
 * Josh will leave his concern in place regarding shorthand until is added
@@ -226,7 +226,7 @@ enum Option<T> {
 
 **Link:** https://github.com/rust-lang/rust/pull/84414
 
-* [Consensus from last meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-06-22.md#allow-struct-and-enum-to-contain-inner-attrs-rust84414):
+* [Consensus from last meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-06-22.md#allow-struct-and-enum-to-contain-inner-attrs-rust84414):
     * We shouldn't leave this open
     * Some people have mild preferences one way, some the other
     * Don't have a full quorum for the team here, wait a bit
@@ -255,7 +255,7 @@ enum Foo { .. from header .. }
 
 **Link:** https://github.com/rust-lang/rust/pull/84838
 
-* [Consensus from last meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-06-22.md#implement-default-for-all-arrays-rust84838):
+* [Consensus from last meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-06-22.md#implement-default-for-all-arrays-rust84838):
     * ~~fcp merge, Niko to write-up (didn't happen yet)~~
 * Concern about maintenance from a libs perspective:
     * This is very complex and hacky

--- a/minutes/2021-07-13.md
+++ b/minutes/2021-07-13.md
@@ -372,7 +372,7 @@ scottmcm comments:
 
 **Link:** https://github.com/rust-lang/rust/pull/86492
 
-* [Discussed in previous meeting](https://github.com/rust-lang/lang-team/blob/master/minutes/2021-07-06.md#associated-functions-that-contain-extern-indicator-or-have-rustc_std_internal_symbol-are-reachable-rust86492)
+* [Discussed in previous meeting](https://github.com/rust-lang/lang-team/blob/main/minutes/2021-07-06.md#associated-functions-that-contain-extern-indicator-or-have-rustc_std_internal_symbol-are-reachable-rust86492)
 * TL;DR
     * `#[no_mangle]` on an inherent method currently is not considered reachable, but is allowed
     * Clear that we have a couple of stabs in a larger design space

--- a/minutes/2021-09-21.md
+++ b/minutes/2021-09-21.md
@@ -31,7 +31,7 @@ tags: triage-meeting
     * Stakeholders?
         * Taylor 
         * DST folks (Simon?)
-    * [Previous meeting notes](https://github.com/rust-lang/lang-team/blob/master/design-meeting-minutes/2020-11-04-RFC-2580-and-custom-dst.md)
+    * [Previous meeting notes](https://github.com/rust-lang/lang-team/blob/main/design-meeting-minutes/2020-11-04-RFC-2580-and-custom-dst.md)
 
 ### ~const syntax
 

--- a/minutes/2022-10-25.md
+++ b/minutes/2022-10-25.md
@@ -288,7 +288,7 @@ Josh started an FCP and un-nominated.
 
 **Link:** https://github.com/rust-lang/rust/pull/86844
 
-[previous minutes](https://github.com/rust-lang/lang-team/blob/master/minutes/2022-10-11.md#support-global_allocator-without-the-allocator-shim-rust86844)
+[previous minutes](https://github.com/rust-lang/lang-team/blob/main/minutes/2022-10-11.md#support-global_allocator-without-the-allocator-shim-rust86844)
 
 [good comment](https://github.com/rust-lang/rust/pull/86844#issuecomment-894814365)
 

--- a/src/calendar.md
+++ b/src/calendar.md
@@ -27,7 +27,7 @@ Minutes for all of our recent meetings can be found here:
 
 Periodically, we archive our meeting minutes to git:
 
-- [Lang team archived minutes](https://github.com/rust-lang/lang-team/tree/master/minutes)
+- [Lang team archived minutes](https://github.com/rust-lang/lang-team/tree/main/minutes)
 
 ## Subteam Calendars
 

--- a/src/meetings/design.md
+++ b/src/meetings/design.md
@@ -39,5 +39,5 @@ After everyone is done reading, whoever is driving the meeting will pick questio
 
 The [design-meeting-minutes directory][dnm] contains the document from each meeting along with any questions that were asked and the ensuing disceussion.
 
-[dnm]: https://github.com/rust-lang/lang-team/tree/master/design-meeting-minutes
+[dnm]: https://github.com/rust-lang/lang-team/tree/main/design-meeting-minutes
 [ghp]: https://github.com/orgs/rust-lang/projects/31/views/10

--- a/src/meetings/triage.md
+++ b/src/meetings/triage.md
@@ -38,4 +38,4 @@ cargo run --bin lang agenda | hackmd-cli import
 
 [Triage meeting minutes are available in this directory.][tmm]
 
-[tmm]: https://github.com/rust-lang/lang-team/tree/master/minutes
+[tmm]: https://github.com/rust-lang/lang-team/tree/main/minutes

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -18,5 +18,5 @@ Finally, there are often "grey areas" between the language and library teams, su
 
 ## Key links
 
-* [Meeting calendar](./calendar.md), [triage meeting minutes](https://github.com/rust-lang/lang-team/tree/master/minutes), [design meeting minutes](https://github.com/rust-lang/lang-team/tree/master/design-meeting-minutes)
+* [Meeting calendar](./calendar.md), [triage meeting minutes](https://github.com/rust-lang/lang-team/tree/main/minutes), [design meeting minutes](https://github.com/rust-lang/lang-team/tree/main/design-meeting-minutes)
     * You can [read more about our meetings here.](./meetings.md).


### PR DESCRIPTION
`lang-team` side of https://github.com/rust-lang/team/pull/2517.